### PR TITLE
Improved checking of dynamic resize updates

### DIFF
--- a/lib/hpax.ex
+++ b/lib/hpax.ex
@@ -82,7 +82,14 @@ defmodule HPAX do
   # https://datatracker.ietf.org/doc/html/rfc7541#section-4.2
   def decode(<<0b001::3, rest::bitstring>>, %Table{} = table) do
     {new_size, rest} = decode_integer(rest, 5)
-    decode(rest, Table.resize(table, new_size))
+
+    # Dynamic resizes must be less than max table size
+    # https://datatracker.ietf.org/doc/html/rfc7541#section-6.3
+    if new_size <= table.max_table_size do
+      decode(rest, Table.resize(table, new_size))
+    else
+      {:error, :protocol_error}
+    end
   end
 
   def decode(block, %Table{} = table) when is_binary(block) do

--- a/lib/hpax.ex
+++ b/lib/hpax.ex
@@ -77,6 +77,14 @@ defmodule HPAX do
   """
   @spec decode(binary(), Table.t()) ::
           {:ok, [{header_name(), header_value()}], Table.t()} | {:error, term()}
+
+  # Dynamic resizes must occur only at the start of a block
+  # https://datatracker.ietf.org/doc/html/rfc7541#section-4.2
+  def decode(<<0b001::3, rest::bitstring>>, %Table{} = table) do
+    {new_size, rest} = decode_integer(rest, 5)
+    decode(rest, Table.resize(table, new_size))
+  end
+
   def decode(block, %Table{} = table) when is_binary(block) do
     decode_headers(block, table, _acc = [])
   catch
@@ -178,12 +186,6 @@ defmodule HPAX do
 
     # TODO: enforce the "never indexed" part somehow.
     decode_headers(rest, table, [{name, value} | acc])
-  end
-
-  # Dynamic table size update
-  defp decode_headers(<<0b001::3, rest::bitstring>>, table, acc) do
-    {new_size, rest} = decode_integer(rest, 5)
-    decode_headers(rest, Table.resize(table, new_size), acc)
   end
 
   defp decode_headers(_other, _table, _acc) do

--- a/test/hpax_test.exs
+++ b/test/hpax_test.exs
@@ -84,6 +84,19 @@ defmodule HPAXTest do
     end
   end
 
+  # https://datatracker.ietf.org/doc/html/rfc7541#section-6.2
+  property "decode/2 rejects dynamic resizes larger than the original table size" do
+    enc_table = HPAX.new(29)
+    dec_table = HPAX.new(29)
+
+    check all headers_to_encode <- list_of(header_with_store(), min_length: 1) do
+      assert {encoded, _enc_table} = HPAX.encode(headers_to_encode, enc_table)
+
+      encoded = <<0b001::3, 0b11110::5>> <> IO.iodata_to_binary(encoded)
+      assert {:error, :protocol_error} = HPAX.decode(encoded, dec_table)
+    end
+  end
+
   property "encoding then decoding headers is circular" do
     table = HPAX.new(500)
 

--- a/test/hpax_test.exs
+++ b/test/hpax_test.exs
@@ -47,6 +47,43 @@ defmodule HPAXTest do
     assert dec_table.entries == [{"b", "B"}, {"a", "A"}]
   end
 
+  # https://datatracker.ietf.org/doc/html/rfc7541#section-4.2
+  property "decode/2 accepts dynamic resizes at the start of a block" do
+    enc_table = HPAX.new(20_000)
+    # Start with a non-empty decode table
+    dec_table = HPAX.new(20_000)
+    {encoded, _enc_table} = HPAX.encode([{:store, "bogus", "BOGUS"}], dec_table)
+    encoded = IO.iodata_to_binary(encoded)
+    assert {:ok, _decoded, dec_table} = HPAX.decode(encoded, dec_table)
+    assert dec_table.size > 0
+
+    check all headers_to_encode <- list_of(header_with_store(), min_length: 1) do
+      assert {encoded, enc_table} = HPAX.encode(headers_to_encode, enc_table)
+      encoded = IO.iodata_to_binary(encoded)
+      assert {:ok, _decoded, new_dec_table} = HPAX.decode(encoded, dec_table)
+      assert new_dec_table.size > enc_table.size
+
+      # Now prepend a table zeroing to the beginning and ensure that we are exactly
+      # the same size as the encode table
+      encoded = <<0b001::3, 0::5>> <> encoded
+      assert {:ok, _decoded, new_dec_table} = HPAX.decode(encoded, dec_table)
+      assert new_dec_table.size == enc_table.size
+    end
+  end
+
+  # https://datatracker.ietf.org/doc/html/rfc7541#section-4.2
+  property "decode/2 rejects dynamic resizes anywhere but at the start of a block" do
+    enc_table = HPAX.new(20_000)
+    dec_table = HPAX.new(20_000)
+
+    check all headers_to_encode <- list_of(header_with_store(), min_length: 1) do
+      assert {encoded, _enc_table} = HPAX.encode(headers_to_encode, enc_table)
+
+      encoded = IO.iodata_to_binary(encoded) <> <<0b001::3, 0::5>>
+      assert {:error, :protocol_error} = HPAX.decode(encoded, dec_table)
+    end
+  end
+
   property "encoding then decoding headers is circular" do
     table = HPAX.new(500)
 
@@ -84,6 +121,10 @@ defmodule HPAXTest do
                  :hpack.decode(IO.iodata_to_binary(encoded), decode_table)
       end
     end
+  end
+
+  defp header_with_store() do
+    map(header(), fn {name, value} -> {:store, name, value} end)
   end
 
   # Header generator.


### PR DESCRIPTION
This work adds support to catch two cases which were previously allowed by HPax, and which caused failures when testing against the h2spec HPACK suite:

1. We now only accept dynamic header resize updates at the beginning of a block, per  [RFC7541§4.2](https://datatracker.ietf.org/doc/html/rfc7541#section-4.2).
2. We now reject dynamic header resize updates larger than the max table size, per  [RFC7541§6.3](https://datatracker.ietf.org/doc/html/rfc7541#section-6.3).
