### PR TITLE
Use `import Bitwise` instead of `use Bitwise`

### DIFF
--- a/lib/hpax/huffman.ex
+++ b/lib/hpax/huffman.ex
@@ -1,7 +1,7 @@
 defmodule HPAX.Huffman do
   @moduledoc false
 
-  use Bitwise
+  import Bitwise, only: [{:>>>, 2}]
 
   # This file is downloaded from the spec directly.
   # http://httpwg.org/specs/rfc7541.html#huffman.code

--- a/lib/hpax/huffman.ex
+++ b/lib/hpax/huffman.ex
@@ -1,7 +1,7 @@
 defmodule HPAX.Huffman do
   @moduledoc false
 
-  import Bitwise, only: [{:>>>, 2}]
+  import Bitwise, only: [>>>: 2]
 
   # This file is downloaded from the spec directly.
   # http://httpwg.org/specs/rfc7541.html#huffman.code

--- a/lib/hpax/types.ex
+++ b/lib/hpax/types.ex
@@ -1,7 +1,7 @@
 defmodule HPAX.Types do
   @moduledoc false
 
-  import Bitwise, only: [{:<<<, 2}]
+  import Bitwise, only: [<<<: 2]
 
   alias HPAX.Huffman
 

--- a/lib/hpax/types.ex
+++ b/lib/hpax/types.ex
@@ -1,7 +1,7 @@
 defmodule HPAX.Types do
   @moduledoc false
 
-  use Bitwise
+  import Bitwise, only: [{:<<<, 2}]
 
   alias HPAX.Huffman
 


### PR DESCRIPTION
Fixes the deprecation warnings (for Elixir >= `1.14`) for `use Bitwise` and only imports the function which is used in the module.