### PR TITLE
Bump Elixir requirement to 1.7+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,30 +9,30 @@ on:
 jobs:
   test:
     name: Test (Elixir ${{ matrix.elixir }}, OTP ${{ matrix.erlang }})
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
         include:
-          - erlang: "25.0"
-            elixir: "1.13"
+          - erlang: "25.3"
+            elixir: "1.14.2"
             lint: true
             coverage: true
-          - erlang: "18.3"
-            elixir: "1.5.3"
+          - erlang: "20.3"
+            elixir: "1.7.4"
 
     env:
       MIX_ENV: test
-      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v1
 
-      - name: Install OTP and Elixir
-        uses: erlef/setup-elixir@v1
+      - name: Install Erlang and Elixir
+        uses: erlef/setup-beam@v1
         with:
-          otp-version: ${{matrix.erlang}}
-          elixir-version: ${{matrix.elixir}}
+          otp-version: ${{ matrix.erlang }}
+          elixir-version: ${{ matrix.elixir }}
 
       - name: Install dependencies
         run: mix deps.get --only test, deps.compile
@@ -53,23 +53,23 @@ jobs:
 
       - name: Check formatting
         run: mix format --check-formatted
-        if: ${{matrix.lint}}
+        if: ${{ matrix.lint }}
 
       - name: Check for unused dependencies
         run: mix do deps.get, deps.unlock --check-unused
-        if: ${{matrix.lint}}
+        if: ${{ matrix.lint }}
 
       - name: Compile with --warnings-as-errors
         run: mix compile --warnings-as-errors
-        if: ${{matrix.lint}}
+        if: ${{ matrix.lint }}
 
       - name: Run tests
         run: mix test --trace
-        if: ${{!matrix.coverage}}
+        if: ${{ !matrix.coverage }}
 
       - name: Run tests with coverage
         run: mix coveralls.github --trace
-        if: ${{matrix.coverage}}
+        if: ${{ matrix.coverage }}
 
       - name: Run Dialyzer
         run: mix dialyzer

--- a/lib/hpax.ex
+++ b/lib/hpax.ex
@@ -134,11 +134,7 @@ defmodule HPAX do
       #=> {iodata, updated_encoding_context}
 
   """
-  # TODO: remove once we depend on Elixir 1.7+.
-  if Version.match?(System.version(), ">= 1.7.0") do
-    @doc since: "0.2.0"
-  end
-
+  @doc since: "0.2.0"
   @spec encode(action, [header], Table.t()) :: {iodata(), Table.t()}
         when action: :store | :store_name | :no_store | :never_store,
              header: {header_name(), header_value()}

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule HPAX.MixProject do
     [
       app: :hpax,
       version: @version,
-      elixir: "~> 1.5",
+      elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
 


### PR DESCRIPTION
This uses `ubuntu-20.04` on CI, which has kind of become necessary since there are basically no Ubuntu 18.04 workers available anymore, as far as I can tell.

Anyways, time to modernize I guess 🙃 