### PR TITLE
Improve table resizing

### DIFF
--- a/lib/hpax.ex
+++ b/lib/hpax.ex
@@ -127,10 +127,10 @@ defmodule HPAX do
   def decode(<<0b001::3, rest::bitstring>>, %Table{} = table) do
     {new_max_size, rest} = decode_integer(rest, 5)
 
-    # Dynamic resizes must be less than max table size
+    # Dynamic resizes must be less than protocol max table size
     # https://datatracker.ietf.org/doc/html/rfc7541#section-6.3
-    if new_max_size <= table.max_table_size do
-      decode(rest, Table.resize(table, new_max_size))
+    if new_max_size <= table.protocol_max_table_size do
+      decode(rest, Table.dynamic_resize(table, new_max_size))
     else
       {:error, :protocol_error}
     end

--- a/lib/hpax.ex
+++ b/lib/hpax.ex
@@ -88,7 +88,9 @@ defmodule HPAX do
 
   If the indicated size is less than the table's current size, entries
   will be evicted as needed to fit within the specified size, and the table's
-  maximum size will be decreased to the specified value.
+  maximum size will be decreased to the specified value. A flag will also be
+  set which will enqueue a 'dynamic table size update' command to be prefixed
+  to the next block encoded with this table, per RFC9113§4.3.1.
 
   If the indicated size is greater than or equal to the table's current max size, no entries are evicted
   and the table's maximum size changes to the specified value.
@@ -158,7 +160,9 @@ defmodule HPAX do
         when header: {action, header_name(), header_value()},
              action: :store | :store_name | :no_store | :never_store
   def encode(headers, %Table{} = table) when is_list(headers) do
-    encode_headers(headers, table, _acc = [])
+    {table, pending_resizes} = Table.pending_resizes(table)
+    acc = pending_resizes |> Enum.map(&[<<0b001::3, Types.encode_integer(&1, 5)::bitstring>>])
+    encode_headers(headers, table, acc)
   end
 
   @doc """

--- a/lib/hpax.ex
+++ b/lib/hpax.ex
@@ -82,15 +82,17 @@ defmodule HPAX do
   end
 
   @doc """
-  Resizes the given table to the given maximum size. Intended for use where the
-  overlying protocol has signalled a change to the table's maximum size,
-  such as when an HTTP/2 Settings frame is received.
+  Resizes the given table to the given maximum size.
+
+  This is intended for use where the overlying protocol has signaled a change to the table's
+  maximum size, such as when an HTTP/2 `SETTINGS` frame is received.
 
   If the indicated size is less than the table's current size, entries
   will be evicted as needed to fit within the specified size, and the table's
   maximum size will be decreased to the specified value. A flag will also be
-  set which will enqueue a 'dynamic table size update' command to be prefixed
-  to the next block encoded with this table, per RFC9113§4.3.1.
+  set which will enqueue a "dynamic table size update" command to be prefixed
+  to the next block encoded with this table, per
+  [RFC9113§4.3.1](https://www.rfc-editor.org/rfc/rfc9113.html#section-4.3.1).
 
   If the indicated size is greater than or equal to the table's current max size, no entries are evicted
   and the table's maximum size changes to the specified value.
@@ -160,8 +162,8 @@ defmodule HPAX do
         when header: {action, header_name(), header_value()},
              action: :store | :store_name | :no_store | :never_store
   def encode(headers, %Table{} = table) when is_list(headers) do
-    {table, pending_resizes} = Table.pending_resizes(table)
-    acc = pending_resizes |> Enum.map(&[<<0b001::3, Types.encode_integer(&1, 5)::bitstring>>])
+    {table, pending_resizes} = Table.pop_pending_resizes(table)
+    acc = Enum.map(pending_resizes, &[<<0b001::3, Types.encode_integer(&1, 5)::bitstring>>])
     encode_headers(headers, table, acc)
   end
 

--- a/test/hpax/table_test.exs
+++ b/test/hpax/table_test.exs
@@ -71,21 +71,34 @@ defmodule HPAX.TableTest do
   end
 
   describe "resizing" do
-    test "increasing the max table size" do
+    test "increasing the protocol max table size" do
       table = Table.new(4096, :never)
       table = Table.add(table, "aaaa", "AAAA")
       table = Table.resize(table, 8192)
       assert table.size == 40
       assert table.max_table_size == 8192
+      assert table.protocol_max_table_size == 8192
     end
 
-    test "decreasing the max table size" do
+    test "decreasing the protocol max table size not below the max table size" do
+      table = Table.new(4096, :never)
+      table = Table.add(table, "aaaa", "AAAA")
+      table = Table.add(table, "bbbb", "BBBB")
+      table = Table.dynamic_resize(table, 2048)
+      table = Table.resize(table, 6000)
+      assert table.size == 40
+      assert table.max_table_size == 6000
+      assert table.protocol_max_table_size == 6000
+    end
+
+    test "decreasing the protocol max table size below the max table size" do
       table = Table.new(4096, :never)
       table = Table.add(table, "aaaa", "AAAA")
       table = Table.add(table, "bbbb", "BBBB")
       table = Table.resize(table, 40)
       assert table.size == 40
       assert table.max_table_size == 40
+      assert table.protocol_max_table_size == 40
     end
   end
 end

--- a/test/hpax_test.exs
+++ b/test/hpax_test.exs
@@ -107,6 +107,39 @@ defmodule HPAXTest do
     end
   end
 
+  property "encode/3 prepends dynamic resizes at the start of a block" do
+    enc_table = HPAX.new(20_000)
+    # Start with a non-empty decode table
+    dec_table = HPAX.new(20_000)
+
+    # Put a record in both to prime the pump. The table sizes should match
+    {encoded, enc_table} = HPAX.encode([{:store, "bogus", "BOGUS"}], enc_table)
+    encoded = IO.iodata_to_binary(encoded)
+    assert {:ok, _decoded, dec_table} = HPAX.decode(encoded, dec_table)
+    assert dec_table.size == enc_table.size
+    assert enc_table.max_table_size == 20_000
+    assert dec_table.max_table_size == 20_000
+
+    # Encode a record after resizing the table. We expect a dynamic resize to be
+    # encoded and the for two table sizes to be identical after decoding
+    enc_table = HPAX.resize(enc_table, 0)
+    enc_table = HPAX.resize(enc_table, 1234)
+    {encoded, enc_table} = HPAX.encode([{:store, "lame", "LAME"}], enc_table)
+    encoded = IO.iodata_to_binary(encoded)
+
+    # Ensure that we see two resizes in order
+    assert <<0b001::3, rest::bitstring>> = encoded
+    assert {:ok, 0, rest} = HPAX.Types.decode_integer(rest, 5)
+    assert <<0b001::3, rest::bitstring>> = rest
+    assert {:ok, 1234, _rest} = HPAX.Types.decode_integer(rest, 5)
+
+    # Finally, ensure that the decoder makes proper sense of this encoding
+    assert {:ok, _decoded, dec_table} = HPAX.decode(encoded, dec_table)
+    assert dec_table.size == enc_table.size
+    assert enc_table.max_table_size == 1234
+    assert dec_table.max_table_size == 1234
+  end
+
   # https://datatracker.ietf.org/doc/html/rfc7541#section-4.2
   property "decode/2 accepts dynamic resizes at the start of a block" do
     enc_table = HPAX.new(20_000)


### PR DESCRIPTION
Fixes #18.

* Introduce a new `protocol_max_table_size` field on tables, which records the containing protocol (ie: HTTP/2's) view of the max allowable table size. Dynamic resizes validate the new size against this value.
* Dynamic resizes now update the `max_table_size` value on tables (evicting as needed to satisfy)
* Changes to `max_protocol_table_size` on the encoder are signalled to the decoder via dynamic table size update messages