### PR TITLE
Table size fixes

### DIFF
--- a/lib/hpax/table.ex
+++ b/lib/hpax/table.ex
@@ -317,6 +317,8 @@ defmodule HPAX.Table do
 
   # Removes records as necessary to have the total size of entries within the table be less than
   # or equal to the specified value. Does not change the table's max size.
+  defp evict_to_size(%__MODULE__{size: size} = table, new_size) when size <= new_size, do: table
+
   defp evict_to_size(%__MODULE__{entries: entries, size: size} = table, new_size) do
     {new_entries_reversed, new_size} =
       evict_towards_size(Enum.reverse(entries), size, new_size)

--- a/test/hpax/table_test.exs
+++ b/test/hpax/table_test.exs
@@ -70,7 +70,7 @@ defmodule HPAX.TableTest do
     end
   end
 
-  describe "resizing" do
+  describe "resize/2" do
     test "increasing the protocol max table size" do
       table = Table.new(4096, :never)
       table = Table.add(table, "aaaa", "AAAA")
@@ -80,25 +80,44 @@ defmodule HPAX.TableTest do
       assert table.protocol_max_table_size == 8192
     end
 
-    test "decreasing the protocol max table size not below the max table size" do
+    test "decreasing the protocol max table size but above table size" do
       table = Table.new(4096, :never)
       table = Table.add(table, "aaaa", "AAAA")
-      table = Table.add(table, "bbbb", "BBBB")
-      table = Table.dynamic_resize(table, 2048)
-      table = Table.resize(table, 6000)
+      table = Table.resize(table, 2048)
       assert table.size == 40
-      assert table.max_table_size == 6000
-      assert table.protocol_max_table_size == 6000
+      assert table.max_table_size == 2048
+      assert table.protocol_max_table_size == 2048
     end
 
-    test "decreasing the protocol max table size below the max table size" do
+    test "decreasing the protocol max table size below current size should evict" do
       table = Table.new(4096, :never)
       table = Table.add(table, "aaaa", "AAAA")
       table = Table.add(table, "bbbb", "BBBB")
-      table = Table.resize(table, 40)
+      table = Table.resize(table, 60)
       assert table.size == 40
-      assert table.max_table_size == 40
-      assert table.protocol_max_table_size == 40
+      assert table.max_table_size == 60
+      assert table.protocol_max_table_size == 60
+    end
+  end
+
+  describe "dynamic_resize/2" do
+    test "decreasing the max table size but above table size" do
+      table = Table.new(4096, :never)
+      table = Table.add(table, "aaaa", "AAAA")
+      table = Table.dynamic_resize(table, 2048)
+      assert table.size == 40
+      assert table.max_table_size == 2048
+      assert table.protocol_max_table_size == 4096
+    end
+
+    test "decreasing the protocol max table size below current size should evict" do
+      table = Table.new(4096, :never)
+      table = Table.add(table, "aaaa", "AAAA")
+      table = Table.add(table, "bbbb", "BBBB")
+      table = Table.dynamic_resize(table, 60)
+      assert table.size == 40
+      assert table.max_table_size == 60
+      assert table.protocol_max_table_size == 4096
     end
   end
 end


### PR DESCRIPTION
Fixes #20.

This changes our resize code to *always* send a dynamic table resize command, even if the table size did not change from the commanded version. This is in line with a closer read of Closer [RFC9113§4.3.1 paragraph 4](https://www.rfc-editor.org/rfc/rfc9113.html#section-4.3.1). 

I also fixed the evict_towards_size internal table function to handle the case where it was being asked to evict to a size greater than the table's current actual size. Previously we were *always* evicting at least one entry even if it wasn't necessary.