### PR TITLE
Improve error message on invalid headers

### DIFF
--- a/lib/hpax.ex
+++ b/lib/hpax.ex
@@ -298,7 +298,8 @@ defmodule HPAX do
   end
 
   defp encode_headers([{action, name, value} | rest], table, acc)
-       when action in @valid_header_actions and is_binary(name) and is_binary(value) do
+       when action in @valid_header_actions do
+    validate_header(name, value)
     huffman? = table.huffman_encoding == :always
 
     {encoded, table} =
@@ -328,6 +329,15 @@ defmodule HPAX do
       end
 
     encode_headers(rest, table, [acc, encoded])
+  end
+
+  defp validate_header(name, value) when is_binary(name) and is_binary(value) do
+    :ok
+  end
+
+  defp validate_header(name, value) do
+    raise ArgumentError,
+          "expected header name/value to be strings, got: #{inspect(name)}/#{inspect(value)}"
   end
 
   defp encode_indexed_header(index) do

--- a/test/hpax_test.exs
+++ b/test/hpax_test.exs
@@ -95,6 +95,22 @@ defmodule HPAXTest do
     assert dec_table.entries == [{"b", "B"}, {"a", "A"}]
   end
 
+  test "encode/3 with invalid headers" do
+    table = HPAX.new(1000)
+
+    assert_raise ArgumentError,
+                 ~s(expected header name/value to be strings, got: :foo/"bar"),
+                 fn ->
+                   HPAX.encode([{:store, :foo, "bar"}], table)
+                 end
+
+    assert_raise ArgumentError,
+                 ~s(expected header name/value to be strings, got: "foo"/:bar),
+                 fn ->
+                   HPAX.encode([{:store, "foo", :bar}], table)
+                 end
+  end
+
   property "encode/3 with a single action" do
     table = HPAX.new(500)
 


### PR DESCRIPTION
Ref: https://github.com/elixir-mint/mint/pull/468

With this patch in Mint we now have:

```
iex> {:ok, conn} = Mint.HTTP2.connect(:https, "httpbin.org", 443) ; Mint.HTTP.request(conn, "GET", "/json", [{"accept", nil}], nil)
** (ArgumentError) expected header name/value to be strings, got: "accept"/nil
    (hpax 1.0.3) lib/hpax.ex:339: HPAX.validate_header/2
    (hpax 1.0.3) lib/hpax.ex:302: HPAX.encode_headers/3
    (elixir 1.18.4) lib/map.ex:999: Map.get_and_update!/3
    (mint 1.7.1) lib/mint/http2.ex:1134: Mint.HTTP2.encode_headers/4
    (mint 1.7.1) lib/mint/http2.ex:520: Mint.HTTP2.request/5
    iex:1: (file)
```